### PR TITLE
Fix resume logic in timer control hook

### DIFF
--- a/features/timers/useTimerControls.ts
+++ b/features/timers/useTimerControls.ts
@@ -90,10 +90,42 @@ export default function useTimerControls(
 
   const reset = stop;
 
-  const resume = React.useCallback(() => {
-    // TODO: Implement resume functionality
-    reset?.();
-  }, [reset]);
+  const resume = React.useMemo(() => {
+    if (seconds === null || seconds <= 0) return undefined;
+
+    return () => {
+      // If the timer isn't paused there's nothing to resume
+      if (state.value !== "paused") return;
+
+      state.value = "running";
+
+      const remainingMs = duration.value * 1000;
+
+      duration.value = withTiming(
+        0,
+        {
+          duration: remainingMs,
+          easing: Easing.linear,
+        },
+        (finished) => {
+          if (!finished) return;
+
+          state.value = "stopped";
+          progress.value = 0;
+          duration.value = seconds;
+
+          if (onComplete) {
+            runOnJS(onComplete)();
+          }
+        }
+      );
+
+      progress.value = withTiming(1, {
+        duration: remainingMs,
+        easing: Easing.linear,
+      });
+    };
+  }, [seconds, duration, progress, state, onComplete]);
 
   const addTime = React.useCallback((secondsToAdd: number) => {
     // TODO:


### PR DESCRIPTION
## Summary
- implement resume logic to continue animations from a paused state

## Testing
- `npm run lint` *(fails: package not in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_6845dd3b30f483248b84e5921917a488