### PR TITLE
Update timer state when duration changes

### DIFF
--- a/features/timers/useTimerControls.ts
+++ b/features/timers/useTimerControls.ts
@@ -31,7 +31,8 @@ export default function useTimerControls(
 
   React.useEffect(() => {
     duration.value = seconds === null ? exampleDuration : seconds;
-  }, [seconds, duration]);
+    state.value = "stopped";
+  }, [seconds, duration, state]);
 
   const start = React.useMemo(() => {
     if (seconds === null || seconds <= 0) return undefined;


### PR DESCRIPTION
## Summary
- stop timer whenever the duration prop changes

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6845e4c9640c832492f7ae35c5d13917